### PR TITLE
Remove direct Jest dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,6 @@
         "enzyme": "^3.11.0",
         "enzyme-adapter-react-16": "^1.15.6",
         "enzyme-to-json": "^3.6.2",
-        "jest": "^26.6.0",
         "react-test-renderer": "^17.0.2",
         "ts-jest": "^26.5.4",
         "typescript": "^4.2.4"

--- a/package.json
+++ b/package.json
@@ -59,7 +59,6 @@
     "enzyme": "^3.11.0",
     "enzyme-adapter-react-16": "^1.15.6",
     "enzyme-to-json": "^3.6.2",
-    "jest": "^26.6.0",
     "react-test-renderer": "^17.0.2",
     "ts-jest": "^26.5.4",
     "typescript": "^4.2.4"


### PR DESCRIPTION
Jest version should have been handled by React. Dev dependency was added directly for Jest which had the potential to cause version issues.